### PR TITLE
OpenBSD rc.d/rcctl requires /bin/ksh shebang

### DIFF
--- a/lib/templates/init-scripts/rcd-openbsd.tpl
+++ b/lib/templates/init-scripts/rcd-openbsd.tpl
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/ksh
 #
 # from /usr/ports/infrastructure/templates/rc.template
 


### PR DESCRIPTION
OpenBSD has required the use of /bin/ksh shebang in rc startup scripts since 2018. Without this change, pm2 startup commands fail, with OpenBSD rcctl complaining about wrong shell

<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1234, #5678
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->